### PR TITLE
add maven plugins to build jar-with-dependencies and .exe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,75 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>project_16x16.SideScroller</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>target/win32/java</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${java.home}</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.akathist.maven.plugins.launch4j</groupId>
+        <artifactId>launch4j-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>l4j-project_16x16</id>
+            <phase>package</phase>
+            <goals>
+              <goal>launch4j</goal>
+            </goals>
+            <configuration>
+              <headerType>gui</headerType>
+              <outfile>target/${project.artifactId}.exe</outfile>
+              <jar>target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</jar>
+              <classPath>
+                <mainClass>project_16x16.SideScroller</mainClass>
+              </classPath>
+              <jre>
+                <path>./win32/java</path>
+              </jre>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.6.0</version>


### PR DESCRIPTION
```mvn clean package``` gets you a jar-with-dependencies and a .exe under ```/target```. It copies the system JRE into ```/target/win32```, so the .exe is portable as long as it's kept together with the win32 folder. It would be possible to bundle these together in an archive or a self-extracting exe, but I'm not sure how we intend to ultimately distribute the game.