### PR TITLE
Make maven work on macOS/Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </dependency>
     <dependency>
       <groupId>processing</groupId>
-      <artifactId>gicentreutils</artifactId>
+      <artifactId>gicentreUtils</artifactId>
       <version>local</version>
       <type>jar</type>
     </dependency>


### PR DESCRIPTION
Case sensitivity problem. Maybe we should add travis Cl support so this is caught earlier.