### PR TITLE
Refactored GameplayScene's Tools enum and tool variable with classes

### DIFF
--- a/src/main/java/project_16x16/SideScroller.java
+++ b/src/main/java/project_16x16/SideScroller.java
@@ -23,6 +23,7 @@ import project_16x16.components.AnimationComponent;
 import project_16x16.entities.Player;
 import project_16x16.multiplayer.Multiplayer;
 import project_16x16.scene.*;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.ui.Notifications;
 
 /**
@@ -571,7 +572,7 @@ public class SideScroller extends PApplet {
 					m = new Multiplayer(this, true);
 					((GameplayScene) GameScenes.GAME.getScene()).setupMultiplayer(m);
 					swapToScene(GameScenes.GAME);
-					((GameplayScene) GameScenes.GAME.getScene()).changeMode("PLAY");
+					((GameplayScene) GameScenes.GAME.getScene()).changeMode(GameModes.PLAY);
 					stage.setTitle("host");
 					System.out.println("~HOST~");
 				} catch (Exception e) {
@@ -583,7 +584,7 @@ public class SideScroller extends PApplet {
 					m = new Multiplayer(this, false);
 					((GameplayScene) (GameScenes.GAME.getScene())).setupMultiplayer(m);
 					swapToScene(GameScenes.GAME);
-					((GameplayScene) GameScenes.GAME.getScene()).changeMode("PLAY");
+					((GameplayScene) GameScenes.GAME.getScene()).changeMode(GameModes.PLAY);
 					stage.setTitle("client");
 					System.out.println("~CLIENT~");
 				} catch (Exception e) {

--- a/src/main/java/project_16x16/SideScroller.java
+++ b/src/main/java/project_16x16/SideScroller.java
@@ -23,7 +23,6 @@ import project_16x16.components.AnimationComponent;
 import project_16x16.entities.Player;
 import project_16x16.multiplayer.Multiplayer;
 import project_16x16.scene.*;
-import project_16x16.scene.GameplayScene.Tools;
 import project_16x16.ui.Notifications;
 
 /**
@@ -572,7 +571,7 @@ public class SideScroller extends PApplet {
 					m = new Multiplayer(this, true);
 					((GameplayScene) GameScenes.GAME.getScene()).setupMultiplayer(m);
 					swapToScene(GameScenes.GAME);
-					((GameplayScene) GameScenes.GAME.getScene()).tool = Tools.PLAY;
+					((GameplayScene) GameScenes.GAME.getScene()).changeMode("PLAY");
 					stage.setTitle("host");
 					System.out.println("~HOST~");
 				} catch (Exception e) {
@@ -584,7 +583,7 @@ public class SideScroller extends PApplet {
 					m = new Multiplayer(this, false);
 					((GameplayScene) (GameScenes.GAME.getScene())).setupMultiplayer(m);
 					swapToScene(GameScenes.GAME);
-					((GameplayScene) GameScenes.GAME.getScene()).tool = Tools.PLAY;
+					((GameplayScene) GameScenes.GAME.getScene()).changeMode("PLAY");
 					stage.setTitle("client");
 					System.out.println("~CLIENT~");
 				} catch (Exception e) {

--- a/src/main/java/project_16x16/scene/GameplayScene.java
+++ b/src/main/java/project_16x16/scene/GameplayScene.java
@@ -91,7 +91,11 @@ public class GameplayScene extends PScene {
 	// Scroll Bar
 	private ScrollBarVertical scrollBar;
 	
-	private HashMap<String, GameplayMode> modesMap;
+	private HashMap<GameModes, GameplayMode> modesMap;
+	
+	public enum GameModes{
+		MODIFY, PLAY, INVENTORY, SAVE, IMPORT, LOADEXAMPLE, MOVE, TEST,
+	}
 
 	public GameplayMode currentMode;
 
@@ -175,16 +179,16 @@ public class GameplayScene extends PScene {
 		
 		// GameplayModes initialization
 		modesMap = new HashMap<>();
-		modesMap.put("MODIFY", new ModifyGameMode(this, editorItem));
-		modesMap.put("PLAY", new PlayGameMode(this, localPlayer));
-		modesMap.put("INVENTORY", new InventoryGameMode(this));
-		modesMap.put("SAVE", new SaveGameMode(this));
-		modesMap.put("IMPORT", new ImportGameMode(this));
-		modesMap.put("LOADEXAMPLE", new LoadExampleGameMode(this));
-		modesMap.put("MOVE", new MoveGameMode(this));
-		modesMap.put("TEST", new TestGameMode(this));
+		modesMap.put(GameModes.MODIFY, new ModifyGameMode(this, editorItem));
+		modesMap.put(GameModes.PLAY, new PlayGameMode(this, localPlayer));
+		modesMap.put(GameModes.INVENTORY, new InventoryGameMode(this));
+		modesMap.put(GameModes.SAVE, new SaveGameMode(this));
+		modesMap.put(GameModes.IMPORT, new ImportGameMode(this));
+		modesMap.put(GameModes.LOADEXAMPLE, new LoadExampleGameMode(this));
+		modesMap.put(GameModes.MOVE, new MoveGameMode(this));
+		modesMap.put(GameModes.TEST, new TestGameMode(this));
 		
-		currentMode = modesMap.get("MODIFY");
+		currentMode = modesMap.get(GameModes.MODIFY);
 
 		
 		loadLevel(levelString); // TODO change level
@@ -282,15 +286,16 @@ public class GameplayScene extends PScene {
 		int xAnchor = 42;
 		int offset = 48;
 		// GUI Icons
-		currentMode.updateGUIButton(xAnchor, icon_modifyActive, icon_modify, "MODIFY", Utility.hoverScreen(xAnchor, 120, 36, 36));
-		currentMode.updateGUIButton(xAnchor + offset, icon_inventoryActive, icon_inventory, "INVENTORY", Utility.hoverScreen(xAnchor + offset, 120, 36, 36));
-		currentMode.updateGUIButton(xAnchor + offset * 2, icon_playActive, icon_play, "PLAY", Utility.hoverScreen(xAnchor + offset * 2, 120, 36, 36));
-		currentMode.updateGUIButton(xAnchor + offset * 3, icon_saveActive, icon_save, "SAVE", Utility.hoverScreen(xAnchor + offset * 3, 120, 36, 36));
+		currentMode.updateGUIButton(xAnchor, icon_modifyActive, icon_modify, GameModes.MODIFY, Utility.hoverScreen(xAnchor, 120, 36, 36));
+		currentMode.updateGUIButton(xAnchor + offset, icon_inventoryActive, icon_inventory, GameModes.INVENTORY, Utility.hoverScreen(xAnchor + offset, 120, 36, 36));
+		currentMode.updateGUIButton(xAnchor + offset * 2, icon_playActive, icon_play, GameModes.PLAY, Utility.hoverScreen(xAnchor + offset * 2, 120, 36, 36));
+		currentMode.updateGUIButton(xAnchor + offset * 3, icon_saveActive, icon_save, GameModes.SAVE, Utility.hoverScreen(xAnchor + offset * 3, 120, 36, 36));
 		
 		currentMode.updateGUI();
 
-		if (selectionBox != null)
+		if (selectionBox != null) {
 			selectionBox.draw();
+		}
 	}
 
 	/**
@@ -481,7 +486,7 @@ public class GameplayScene extends PScene {
 				}
 				break;
 			case RIGHT :
-				if (currentMode.getModeName().equals("MODIFY")) {
+				if (currentMode.getModeType().equals(GameModes.MODIFY)) { //As the SelectionBox class is private, this has to remain as a type-check and cannot delegate to the currentMode
 					selectionBox = new SelectionBox(mouseDown);
 				}
 				break;
@@ -545,26 +550,26 @@ public class GameplayScene extends PScene {
 		editorItem.focus = false;
 		switch (event.getKeyCode()) {
 			case 49 : // 1
-				changeMode("MODIFY");
+				changeMode(GameModes.MODIFY);
 				break;
 			case 50 : // 2
-				changeMode("INVENTORY");
+				changeMode(GameModes.INVENTORY);
 				scroll_inventory = 0;
 				break;
 			case 51 : // 3
-				changeMode("PLAY");
+				changeMode(GameModes.PLAY);
 				applet.camera.setFollowObject(localPlayer);
 				break;
 			case 52 : // 4
-				changeMode("SAVE");
+				changeMode(GameModes.SAVE);
 				break;
 			case 54 : // 6
-				changeMode("IMPORT");
+				changeMode(GameModes.IMPORT);
 				break;
 			case 69 : // 'e' TODO remove?
-				if (currentMode.getModeName().equals("INVENTORY")) {
+				if (currentMode.getModeType().equals(GameModes.INVENTORY)) {
 				} else {
-					changeMode("INVENTORY");
+					changeMode(GameModes.INVENTORY);
 					editorItem.setMode("ITEM");
 					scroll_inventory = 0;
 				}
@@ -708,7 +713,7 @@ public class GameplayScene extends PScene {
 		}
 	}
 	
-	public void changeMode(String mode) {
+	public void changeMode(GameModes mode) {
 		currentMode = modesMap.get(mode);
 		currentMode.enter();
 	}

--- a/src/main/java/project_16x16/scene/gameplaymodes/GameplayMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/GameplayMode.java
@@ -1,0 +1,66 @@
+package project_16x16.scene.gameplaymodes;
+
+import processing.core.PImage;
+import processing.core.PVector;
+import processing.event.KeyEvent;
+import processing.event.MouseEvent;
+import project_16x16.entities.Player;
+import project_16x16.objects.EditableObject;
+import project_16x16.scene.GameplayScene;
+
+public abstract class GameplayMode {
+
+	protected GameplayScene scene;
+	
+	public GameplayMode(GameplayScene gameplayScene) {
+		this.scene = gameplayScene;
+	}
+	
+	public void enter() {}
+
+	public void displayWorldEdit() {}
+
+	public void updateEditableObject(EditableObject object) {}
+
+	public void displayDestination() {}
+
+	public void updateLocalPlayer(Player localPlayer) {}
+
+	public void displayGUISlots() {
+		scene.displayGUISlots();
+	}
+
+	public void updateGUIButton(int xAnchor, PImage activeIcon, PImage inactiveIcon, String mode, boolean isHighlighted) {
+		if (getModeName().equals(mode)) {
+			drawGUIButton(activeIcon, xAnchor, 120);
+		} else if (isHighlighted){
+			if (scene.applet.mousePressEvent) {
+				scene.changeMode(mode);
+			}
+			drawGUIButton(activeIcon, xAnchor, 120);
+		} else {
+			drawGUIButton(inactiveIcon, xAnchor, 120);
+		}
+	}
+	
+	protected boolean isNotInvalidGUIButtonMode() {
+		return true;
+	}
+
+	protected void drawGUIButton(PImage icon, int x, int y) {
+		scene.image(icon, x, y);
+	}
+	
+	public abstract String getModeName();
+
+	public void updateGUI() {}
+
+	public void mouseDraggedEvent(MouseEvent event, PVector origPos, PVector mouseDown) {}
+
+	public void mouseWheelEvent(MouseEvent event) {}
+
+	public void keyReleasedEvent(KeyEvent event) {
+		scene.switchModeOnKeyEvent(event);
+	}
+
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/GameplayMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/GameplayMode.java
@@ -7,6 +7,7 @@ import processing.event.MouseEvent;
 import project_16x16.entities.Player;
 import project_16x16.objects.EditableObject;
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 
 public abstract class GameplayMode {
 
@@ -30,10 +31,10 @@ public abstract class GameplayMode {
 		scene.displayGUISlots();
 	}
 
-	public void updateGUIButton(int xAnchor, PImage activeIcon, PImage inactiveIcon, String mode, boolean isHighlighted) {
-		if (getModeName().equals(mode)) {
+	public void updateGUIButton(int xAnchor, PImage activeIcon, PImage inactiveIcon, GameModes mode, boolean isHighlighted) {
+		if (getModeType().equals(mode)) {
 			drawGUIButton(activeIcon, xAnchor, 120);
-		} else if (isHighlighted){
+		} else if (isNotInvalidGUIButtonMode() && isHighlighted){
 			if (scene.applet.mousePressEvent) {
 				scene.changeMode(mode);
 			}
@@ -51,7 +52,7 @@ public abstract class GameplayMode {
 		scene.image(icon, x, y);
 	}
 	
-	public abstract String getModeName();
+	public abstract GameModes getModeType();
 
 	public void updateGUI() {}
 

--- a/src/main/java/project_16x16/scene/gameplaymodes/ImportGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/ImportGameMode.java
@@ -1,6 +1,7 @@
 package project_16x16.scene.gameplaymodes;
 
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.ui.Tab;
 import project_16x16.windows.ImportLevelWindow;
 
@@ -11,8 +12,8 @@ public class ImportGameMode extends GameplayMode {
 	}
 
 	@Override
-	public String getModeName() {
-		return "IMPORT";
+	public GameModes getModeType() {
+		return GameModes.IMPORT;
 	}
 	
 	@Override
@@ -32,11 +33,11 @@ public class ImportGameMode extends GameplayMode {
 		
 		if (windowTabs.getButton(0).event()) {
 			windowTabs.moveActive(0);
-			scene.changeMode("LOADEXAMPLE");
+			scene.changeMode(GameModes.LOADEXAMPLE);
 		}
 		if (windowTabs.getButton(1).event()) {
 			windowTabs.moveActive(1);
-			scene.changeMode("SAVE");
+			scene.changeMode(GameModes.SAVE);
 		}
 	}
 

--- a/src/main/java/project_16x16/scene/gameplaymodes/ImportGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/ImportGameMode.java
@@ -1,0 +1,43 @@
+package project_16x16.scene.gameplaymodes;
+
+import project_16x16.scene.GameplayScene;
+import project_16x16.ui.Tab;
+import project_16x16.windows.ImportLevelWindow;
+
+public class ImportGameMode extends GameplayMode {
+
+	public ImportGameMode(GameplayScene gameplayScene) {
+		super(gameplayScene);
+	}
+
+	@Override
+	public String getModeName() {
+		return "IMPORT";
+	}
+	
+	@Override
+	public void updateGUI() {
+		Tab windowTabs = scene.getWindowTabs();
+		ImportLevelWindow window_importlevel = scene.getWindowImportLevel();
+
+		// Import Level
+		if (windowTabs.getActiveButton() != 2) {
+			windowTabs.moveActive(2);
+		}
+		window_importlevel.privacyDisplay();
+		windowTabs.update();
+		windowTabs.display();
+		window_importlevel.update();
+		window_importlevel.display();
+		
+		if (windowTabs.getButton(0).event()) {
+			windowTabs.moveActive(0);
+			scene.changeMode("LOADEXAMPLE");
+		}
+		if (windowTabs.getButton(1).event()) {
+			windowTabs.moveActive(1);
+			scene.changeMode("SAVE");
+		}
+	}
+
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/InventoryGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/InventoryGameMode.java
@@ -1,0 +1,39 @@
+package project_16x16.scene.gameplaymodes;
+
+import processing.event.MouseEvent;
+import project_16x16.scene.GameplayScene;
+
+public class InventoryGameMode extends GameplayMode {
+
+	public InventoryGameMode(GameplayScene gameplayScene) {
+		super(gameplayScene);
+	}
+	
+	@Override
+	public void enter() {
+		scene.setZoomable(false);
+	}
+	
+	@Override
+	public String getModeName() {
+		return "INVENTORY";
+	}
+	
+	@Override
+	public void displayGUISlots() {}
+
+	@Override
+	protected boolean isNotInvalidGUIButtonMode() {
+		return false;
+	}
+	
+	@Override
+	public void updateGUI() {
+		scene.displayCreativeInventory();
+	}
+	
+	@Override
+	public void mouseWheelEvent(MouseEvent event) {
+		scene.scrollInventoryBar(event);
+	}
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/InventoryGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/InventoryGameMode.java
@@ -2,6 +2,7 @@ package project_16x16.scene.gameplaymodes;
 
 import processing.event.MouseEvent;
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 
 public class InventoryGameMode extends GameplayMode {
 
@@ -15,8 +16,8 @@ public class InventoryGameMode extends GameplayMode {
 	}
 	
 	@Override
-	public String getModeName() {
-		return "INVENTORY";
+	public GameModes getModeType() {
+		return GameModes.INVENTORY;
 	}
 	
 	@Override

--- a/src/main/java/project_16x16/scene/gameplaymodes/LoadExampleGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/LoadExampleGameMode.java
@@ -1,6 +1,7 @@
 package project_16x16.scene.gameplaymodes;
 
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.ui.Tab;
 import project_16x16.windows.LoadLevelWindow;
 
@@ -11,8 +12,8 @@ public class LoadExampleGameMode extends GameplayMode {
 	}
 
 	@Override
-	public String getModeName() {
-		return "LOADEXAMPLE";
+	public GameModes getModeType() {
+		return GameModes.LOADEXAMPLE;
 	}
 
 	@Override
@@ -29,11 +30,11 @@ public class LoadExampleGameMode extends GameplayMode {
 		window_loadLevel.update();
 		if (windowTabs.getButton(1).event()) {
 			windowTabs.moveActive(1);
-			scene.changeMode("SAVE");
+			scene.changeMode(GameModes.SAVE);
 		}
 		if (windowTabs.getButton(2).event()) {
 			windowTabs.moveActive(2);
-			scene.changeMode("IMPORT");
+			scene.changeMode(GameModes.IMPORT);
 		}
 	}
 }

--- a/src/main/java/project_16x16/scene/gameplaymodes/LoadExampleGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/LoadExampleGameMode.java
@@ -1,0 +1,39 @@
+package project_16x16.scene.gameplaymodes;
+
+import project_16x16.scene.GameplayScene;
+import project_16x16.ui.Tab;
+import project_16x16.windows.LoadLevelWindow;
+
+public class LoadExampleGameMode extends GameplayMode {
+
+	public LoadExampleGameMode(GameplayScene gameplayScene) {
+		super(gameplayScene);
+	}
+
+	@Override
+	public String getModeName() {
+		return "LOADEXAMPLE";
+	}
+
+	@Override
+	public void updateGUI() {
+		Tab windowTabs = scene.getWindowTabs();
+		LoadLevelWindow window_loadLevel = scene.getWindowLoadLevel();
+		
+		if (windowTabs.getActiveButton() != 0) {
+			windowTabs.moveActive(0);
+		}
+		windowTabs.update();
+		windowTabs.display();
+		window_loadLevel.display();
+		window_loadLevel.update();
+		if (windowTabs.getButton(1).event()) {
+			windowTabs.moveActive(1);
+			scene.changeMode("SAVE");
+		}
+		if (windowTabs.getButton(2).event()) {
+			windowTabs.moveActive(2);
+			scene.changeMode("IMPORT");
+		}
+	}
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/ModifyGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/ModifyGameMode.java
@@ -1,0 +1,65 @@
+package project_16x16.scene.gameplaymodes;
+
+import processing.core.PConstants;
+import processing.core.PVector;
+import processing.event.MouseEvent;
+import project_16x16.entities.Player;
+import project_16x16.objects.EditableObject;
+import project_16x16.objects.EditorItem;
+import project_16x16.scene.GameplayScene;
+
+public class ModifyGameMode extends GameplayMode {
+
+	private EditorItem editorItem;
+
+	public ModifyGameMode(GameplayScene gameplayScene, EditorItem editorItem) {
+		super(gameplayScene);
+		this.editorItem = editorItem;
+	}
+	
+	@Override
+	public void enter() {
+		scene.setZoomable(true);
+	}
+	
+	@Override
+	public String getModeName() {
+		return "MODIFY";
+	}
+
+	@Override
+	public void displayWorldEdit() {
+		scene.displayWorldEdit();
+	}
+	
+	@Override
+	public void updateEditableObject(EditableObject object) {
+		object.updateEdit();
+		object.displayEdit();
+	}
+	
+	@Override
+	public void displayDestination() {
+		editorItem.displayDestination();
+	}
+
+	@Override
+	public void updateLocalPlayer(Player localPlayer) {
+		localPlayer.updateEdit();
+		localPlayer.displayEdit();
+	}
+	
+	@Override
+	public void updateGUI() {
+		editorItem.update();
+		editorItem.display();
+	}
+	
+	@Override
+	public void mouseDraggedEvent(MouseEvent event, PVector origPos, PVector mouseDown) {
+		if (event.getButton() == PConstants.CENTER) { // pan on MMB; TODO fix when zoom != 1.00
+			scene.applet.camera.setCameraPositionNoLerp(
+					PVector.add(origPos, PVector.sub(mouseDown, scene.applet.getMouseCoordScreen())));
+		}
+	}
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/ModifyGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/ModifyGameMode.java
@@ -7,6 +7,7 @@ import project_16x16.entities.Player;
 import project_16x16.objects.EditableObject;
 import project_16x16.objects.EditorItem;
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 
 public class ModifyGameMode extends GameplayMode {
 
@@ -23,8 +24,8 @@ public class ModifyGameMode extends GameplayMode {
 	}
 	
 	@Override
-	public String getModeName() {
-		return "MODIFY";
+	public GameModes getModeType() {
+		return GameModes.MODIFY;
 	}
 
 	@Override

--- a/src/main/java/project_16x16/scene/gameplaymodes/MoveGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/MoveGameMode.java
@@ -1,0 +1,16 @@
+package project_16x16.scene.gameplaymodes;
+
+import project_16x16.scene.GameplayScene;
+
+public class MoveGameMode extends GameplayMode {
+
+	public MoveGameMode(GameplayScene gameplayScene) {
+		super(gameplayScene);
+	}
+
+	@Override
+	public String getModeName() {
+		return "MOVE";
+	}
+
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/MoveGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/MoveGameMode.java
@@ -1,6 +1,7 @@
 package project_16x16.scene.gameplaymodes;
 
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 
 public class MoveGameMode extends GameplayMode {
 
@@ -9,8 +10,8 @@ public class MoveGameMode extends GameplayMode {
 	}
 
 	@Override
-	public String getModeName() {
-		return "MOVE";
+	public GameModes getModeType() {
+		return GameModes.MOVE;
 	}
 
 }

--- a/src/main/java/project_16x16/scene/gameplaymodes/PlayGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/PlayGameMode.java
@@ -1,0 +1,43 @@
+package project_16x16.scene.gameplaymodes;
+
+import project_16x16.entities.Player;
+import project_16x16.objects.EditableObject;
+import project_16x16.objects.GameObject;
+import project_16x16.scene.GameplayScene;
+
+public class PlayGameMode extends GameplayMode {
+
+	private Player localPlayer;
+
+	public PlayGameMode(GameplayScene gameplayScene, Player localPlayer) {
+		super(gameplayScene);
+		this.localPlayer = localPlayer;
+	}
+	
+	@Override
+	public void enter() {
+		scene.setZoomable(true);
+	}
+
+	@Override
+	public String getModeName() {
+		return "PLAY";
+	}
+
+	@Override
+	public void updateEditableObject(EditableObject object) {
+		if (object instanceof GameObject) {
+			((GameObject) object).update();
+		}
+	}
+	
+	@Override
+	public void updateLocalPlayer(Player localPlayer) {
+		localPlayer.update();
+	}
+
+	@Override
+	public void updateGUI() {
+		localPlayer.displayLife();
+	}
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/PlayGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/PlayGameMode.java
@@ -4,6 +4,7 @@ import project_16x16.entities.Player;
 import project_16x16.objects.EditableObject;
 import project_16x16.objects.GameObject;
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 
 public class PlayGameMode extends GameplayMode {
 
@@ -20,8 +21,8 @@ public class PlayGameMode extends GameplayMode {
 	}
 
 	@Override
-	public String getModeName() {
-		return "PLAY";
+	public GameModes getModeType() {
+		return GameModes.PLAY;
 	}
 
 	@Override

--- a/src/main/java/project_16x16/scene/gameplaymodes/SaveGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/SaveGameMode.java
@@ -1,0 +1,60 @@
+package project_16x16.scene.gameplaymodes;
+
+import processing.event.KeyEvent;
+import project_16x16.scene.GameplayScene;
+import project_16x16.ui.Tab;
+import project_16x16.windows.SaveLevelWindow;
+
+public class SaveGameMode extends GameplayMode {
+
+	public SaveGameMode(GameplayScene gameplayScene) {
+		super(gameplayScene);
+	}
+	
+	@Override
+	public void enter() {
+		scene.setZoomable(false);
+	}
+	
+	@Override
+	public String getModeName() {
+		return "SAVE";
+	}
+
+	@Override
+	protected boolean isNotInvalidGUIButtonMode() {
+		return false;
+	}
+	
+	@Override
+	public void updateGUI() {
+		// Save , Load
+		// The if statement below should be used in each window that includes a tab.
+		// switch the number to the id of the button it's checking for
+		
+		Tab windowTabs = scene.getWindowTabs();
+		SaveLevelWindow window_saveLevel = scene.getWindowSaveLevel();
+		
+		if (windowTabs.getActiveButton() != 1) {
+			windowTabs.moveActive(1);
+		}
+		window_saveLevel.privacyDisplay();
+		windowTabs.update();
+		windowTabs.display();
+		window_saveLevel.update();
+		window_saveLevel.display();
+		// This is an example of how to switch windows when another tab button is
+		// pressed.
+		if (windowTabs.getButton(0).event()) {
+			windowTabs.moveActive(0);
+			scene.changeMode("LOADEXAMPLE");
+		}
+		if (windowTabs.getButton(2).event()) {
+			windowTabs.moveActive(2);
+			scene.changeMode("IMPORT");
+		}
+	}
+	
+	@Override
+	public void keyReleasedEvent(KeyEvent event) {}
+}

--- a/src/main/java/project_16x16/scene/gameplaymodes/SaveGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/SaveGameMode.java
@@ -2,6 +2,7 @@ package project_16x16.scene.gameplaymodes;
 
 import processing.event.KeyEvent;
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.ui.Tab;
 import project_16x16.windows.SaveLevelWindow;
 
@@ -17,8 +18,8 @@ public class SaveGameMode extends GameplayMode {
 	}
 	
 	@Override
-	public String getModeName() {
-		return "SAVE";
+	public GameModes getModeType() {
+		return GameModes.SAVE;
 	}
 
 	@Override
@@ -47,11 +48,11 @@ public class SaveGameMode extends GameplayMode {
 		// pressed.
 		if (windowTabs.getButton(0).event()) {
 			windowTabs.moveActive(0);
-			scene.changeMode("LOADEXAMPLE");
+			scene.changeMode(GameModes.LOADEXAMPLE);
 		}
 		if (windowTabs.getButton(2).event()) {
 			windowTabs.moveActive(2);
-			scene.changeMode("IMPORT");
+			scene.changeMode(GameModes.IMPORT);
 		}
 	}
 	

--- a/src/main/java/project_16x16/scene/gameplaymodes/TestGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/TestGameMode.java
@@ -1,6 +1,7 @@
 package project_16x16.scene.gameplaymodes;
 
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 
 public class TestGameMode extends GameplayMode {
 
@@ -9,8 +10,8 @@ public class TestGameMode extends GameplayMode {
 	}
 
 	@Override
-	public String getModeName() {
-		return "TEST";
+	public GameModes getModeType() {
+		return GameModes.TEST;
 	}
 
 }

--- a/src/main/java/project_16x16/scene/gameplaymodes/TestGameMode.java
+++ b/src/main/java/project_16x16/scene/gameplaymodes/TestGameMode.java
@@ -1,0 +1,16 @@
+package project_16x16.scene.gameplaymodes;
+
+import project_16x16.scene.GameplayScene;
+
+public class TestGameMode extends GameplayMode {
+
+	public TestGameMode(GameplayScene gameplayScene) {
+		super(gameplayScene);
+	}
+
+	@Override
+	public String getModeName() {
+		return "TEST";
+	}
+
+}

--- a/src/main/java/project_16x16/windows/ImportLevelWindow.java
+++ b/src/main/java/project_16x16/windows/ImportLevelWindow.java
@@ -87,13 +87,13 @@ public class ImportLevelWindow extends PClass {
 		if (pressImport.event()) {
 			Utility.convertTiledLevel(jsonPath + input.getText() + ".json", input.getText());
 			input.setText("");
-			scene.tool = GameplayScene.Tools.MOVE;
+			scene.changeMode("MOVE");
 		}
 
 		pressCancel.update();
 		if (pressCancel.event()) {
 			input.setText("");
-			scene.tool = GameplayScene.Tools.MOVE;
+			scene.changeMode("MOVE");
 		}
 	}
 }

--- a/src/main/java/project_16x16/windows/ImportLevelWindow.java
+++ b/src/main/java/project_16x16/windows/ImportLevelWindow.java
@@ -4,6 +4,7 @@ import project_16x16.PClass;
 import project_16x16.SideScroller;
 import project_16x16.Utility;
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.ui.Button;
 import project_16x16.ui.TextInputField;
 
@@ -87,13 +88,13 @@ public class ImportLevelWindow extends PClass {
 		if (pressImport.event()) {
 			Utility.convertTiledLevel(jsonPath + input.getText() + ".json", input.getText());
 			input.setText("");
-			scene.changeMode("MOVE");
+			scene.changeMode(GameModes.MOVE);
 		}
 
 		pressCancel.update();
 		if (pressCancel.event()) {
 			input.setText("");
-			scene.changeMode("MOVE");
+			scene.changeMode(GameModes.MOVE);
 		}
 	}
 }

--- a/src/main/java/project_16x16/windows/LoadLevelWindow.java
+++ b/src/main/java/project_16x16/windows/LoadLevelWindow.java
@@ -93,14 +93,14 @@ public class LoadLevelWindow extends PClass {
 			scene.loadLevel(path + list.getElement());
 			Notifications.addNotification("Level Loaded", "Loaded "+ list.getElement() + ".");
 			list.resetElement();
-			scene.tool = GameplayScene.Tools.MODIFY;
+			scene.changeMode("MODIFY");
 		} else if (list.getConfirmPress() && list.getElement().isEmpty())
-			scene.tool = GameplayScene.Tools.MODIFY;
+			scene.changeMode("MODIFY");
 	}
 
 	public void cancelButton() {
 		if (list.getCancelPress()) {
-			scene.tool = GameplayScene.Tools.MODIFY;
+			scene.changeMode("MODIFY");
 			list.resetElement();
 		}
 	}

--- a/src/main/java/project_16x16/windows/LoadLevelWindow.java
+++ b/src/main/java/project_16x16/windows/LoadLevelWindow.java
@@ -1,6 +1,7 @@
 package project_16x16.windows;
 
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.PClass;
 import project_16x16.SideScroller;
 import project_16x16.Utility;
@@ -93,14 +94,14 @@ public class LoadLevelWindow extends PClass {
 			scene.loadLevel(path + list.getElement());
 			Notifications.addNotification("Level Loaded", "Loaded "+ list.getElement() + ".");
 			list.resetElement();
-			scene.changeMode("MODIFY");
+			scene.changeMode(GameModes.MODIFY);
 		} else if (list.getConfirmPress() && list.getElement().isEmpty())
-			scene.changeMode("MODIFY");
+			scene.changeMode(GameModes.MODIFY);
 	}
 
 	public void cancelButton() {
 		if (list.getCancelPress()) {
-			scene.changeMode("MODIFY");
+			scene.changeMode(GameModes.MODIFY);
 			list.resetElement();
 		}
 	}

--- a/src/main/java/project_16x16/windows/SaveLevelWindow.java
+++ b/src/main/java/project_16x16/windows/SaveLevelWindow.java
@@ -82,13 +82,13 @@ public class SaveLevelWindow extends PClass {
 		if (pressSave.event()) {
 			scene.saveLevel(path + input.getText() + ".dat");
 			input.setText("");
-			scene.tool = GameplayScene.Tools.MODIFY;
+			scene.changeMode("MODIFY");
 		}
 
 		pressCancel.update();
 		if (pressCancel.event()) {
 			input.setText("");
-			scene.tool = GameplayScene.Tools.MODIFY;
+			scene.changeMode("MODIFY");
 		}
 	}
 }

--- a/src/main/java/project_16x16/windows/SaveLevelWindow.java
+++ b/src/main/java/project_16x16/windows/SaveLevelWindow.java
@@ -1,6 +1,7 @@
 package project_16x16.windows;
 
 import project_16x16.scene.GameplayScene;
+import project_16x16.scene.GameplayScene.GameModes;
 import project_16x16.PClass;
 import project_16x16.SideScroller;
 import project_16x16.ui.TextInputField;
@@ -82,13 +83,13 @@ public class SaveLevelWindow extends PClass {
 		if (pressSave.event()) {
 			scene.saveLevel(path + input.getText() + ".dat");
 			input.setText("");
-			scene.changeMode("MODIFY");
+			scene.changeMode(GameModes.MODIFY);
 		}
 
 		pressCancel.update();
 		if (pressCancel.event()) {
 			input.setText("");
-			scene.changeMode("MODIFY");
+			scene.changeMode(GameModes.MODIFY);
 		}
 	}
 }


### PR DESCRIPTION
Fix for #144 

* Created abstract class GameplayMode, which inherits to the concrete gameplay modes as they existed on the Tools enum, being:
	* ModifyGameMode
	* PlayGameMode
	* InventoryGameMode
	* SaveGameMode
	* ImportGameMode
	* LoadExampleGameMode
	* MoveGameMode
	* TestGameMode
* Replaced Tools enum in GameplayScene with a private variable modesMap, a HashMap<string, GameplayMode>, initialized and filled on GameplayScene.setup() method.
* Replaced tool variable on GameplayScene with one public variable called currentMode, a concrete GameplayMode.
* Added method changeMode(string), which swaps the currentMode with one from the map based on the given string key, and fires the GameplayMode method enter() on the new currentMode.
* Replaced all direct calls on the 'tool' variable from across the project with method calls, concrete or abstract, on GameplayMode, avoiding type checking as much as possible and moving the responsibility of handling the mode logic to the GameplayMode.
* Created new methods and slightly altered others in GameplayScene, such as changing displayCreativeInventory from private to public, in response to moving some handling logic to objects external to GameplayScene.